### PR TITLE
Fix armoury harvester counts and units-killed stat

### DIFF
--- a/tt/src/main/java/com/oddlabs/tt/model/Unit.java
+++ b/tt/src/main/java/com/oddlabs/tt/model/Unit.java
@@ -30,7 +30,10 @@ import com.oddlabs.tt.particle.BalancedParametricEmitter;
 import com.oddlabs.tt.particle.StunFunction;
 import com.oddlabs.tt.pathfinder.Movable;
 import com.oddlabs.tt.pathfinder.Occupant;
+import com.oddlabs.tt.pathfinder.PathFinder;
 import com.oddlabs.tt.pathfinder.PathTracker;
+import com.oddlabs.tt.pathfinder.Region;
+import com.oddlabs.tt.pathfinder.TargetRegionFinder;
 import com.oddlabs.tt.pathfinder.UnitGrid;
 import com.oddlabs.tt.player.Player;
 import com.oddlabs.tt.render.SpriteKey;
@@ -592,6 +595,15 @@ public class Unit extends Selectable<UnitTemplate> implements Occupant, Movable 
         return target instanceof Supply && getAbilities().hasAbilities(Abilities.BUILD);
     }
 
+    private @Nullable Building nearestSupplyBuilding(@NonNull Supply supply) {
+        UnitGrid grid = getUnitGrid();
+        BuildingFinder finder = new BuildingFinder(getOwner(), Abilities.SUPPLY_CONTAINER);
+        Region region = PathFinder.findPathRegion(grid, new TargetRegionFinder(grid, finder),
+                grid.getRegion(supply.getGridX(), supply.getGridY()));
+        Building building = region != null ? finder.getOccupantFromRegion(region, true) : null;
+        return building != null ? building.getBase() : null;
+    }
+
     private boolean canRepair(@NonNull Target target, boolean action_repair) {
         return target instanceof Building building &&
                 getAbilities().hasAbilities(Abilities.BUILD) &&
@@ -633,7 +645,8 @@ public class Unit extends Selectable<UnitTemplate> implements Occupant, Movable 
                 if (canBuild(target)) {
                     pushController(new PlaceBuildingController(this, (Building) target));
                 } else if (canGather(target)) {
-                    pushController(new GatherController(this, (Supply) target, ((Supply) target).getClass()));
+                    pushController(new GatherController(this, (Supply) target, ((Supply) target).getClass(),
+                            nearestSupplyBuilding((Supply) target)));
                 } else if (canRepair(target, false)) {
                     pushController(new RepairController(this, (Building) target));
                 } else if (canEnter(target)) {
@@ -660,7 +673,8 @@ public class Unit extends Selectable<UnitTemplate> implements Occupant, Movable 
                 break;
             case GATHER_REPAIR:
                 if (canGather(target)) {
-                    pushController(new GatherController(this, (Supply) target, ((Supply) target).getClass()));
+                    pushController(new GatherController(this, (Supply) target, ((Supply) target).getClass(),
+                            nearestSupplyBuilding((Supply) target)));
                 } else if (canRepair(target, true)) {
                     pushController(new RepairController(this, (Building) target));
                 }

--- a/tt/src/main/java/com/oddlabs/tt/model/Unit.java
+++ b/tt/src/main/java/com/oddlabs/tt/model/Unit.java
@@ -500,11 +500,13 @@ public class Unit extends Selectable<UnitTemplate> implements Occupant, Movable 
         } else if (!isDead()) {
             hit_points = Math.clamp(hit_points - damage, 0, getTemplate().getMaxHitPoints());
             if (hit_points == 0) {
+                owner.unitKilled();
                 if (mounted_building instanceof Ship ship) {
                     ship.getShipHR().removeUnit(this);
                     drown();
                 } else {
                     startDying();
+                    setDirection(-direction_x, -direction_y);
                 }
             }
         }

--- a/tt/src/main/java/com/oddlabs/tt/player/Player.java
+++ b/tt/src/main/java/com/oddlabs/tt/player/Player.java
@@ -461,7 +461,7 @@ public final class Player implements PlayerInterface {
 
             for (Selectable<?> s : units.getSet()) {
                 if (s instanceof Unit unit && s.getPrimaryController() instanceof GatherController<?> gather) {
-                    if (gather.getSupplyType() == supply_type) {
+                    if (gather.getSupplyType() == supply_type && gather.getAssignedBuilding() == building) {
                         float dx = s.getPositionX() - bx;
                         float dy = s.getPositionY() - by;
                         float dist_sq = dx * dx + dy * dy;


### PR DESCRIPTION
Fixes the regressions reported on main:

- Units killed showed 0 for everyone at endgame. The ships port dropped the `unitKilled()` call in `Unit.hit`; restored along with the lost corpse facing.
- Free peons ordered to harvest were not counted by any armoury. They are now assigned a supply building at order time, chosen by the same region finder the gather controller used at dropoff, searched from the resource so the choice matches the old behaviour.
- Decrementing harvesters could recall peons that were unassigned or belonged to another armoury. Recall now only picks peons assigned to the selected building, matching the count.

Note: free harvesters keep delivering to their assigned building instead of re-picking the nearest each trip. Small sim behaviour change, accepted.