### PR TITLE
Fixing weird water reflections

### DIFF
--- a/tt/src/main/java/com/oddlabs/tt/landscape/HeightMap.java
+++ b/tt/src/main/java/com/oddlabs/tt/landscape/HeightMap.java
@@ -275,6 +275,19 @@ public final class HeightMap {
         return false;
     }
 
+    public boolean isAboveSeaLevel(int patch_x, int patch_y) {
+        int offset_x = patch_x * getGridUnitsPerPatch();
+        int offset_y = patch_y * getGridUnitsPerPatch();
+        for (int y = 0; y < getGridUnitsPerPatch(); y++) {
+            for (int x = 0; x < getGridUnitsPerPatch(); x++) {
+                float height = getWrappedHeight(offset_x + x, offset_y + y);
+                if (height > getSeaLevelMeters())
+                    return true;
+            }
+        }
+        return false;
+    }
+
     public LandscapeLeaf getLeafFromCoordinates(float x_f, float y_f) {
         int patch_x = coordinateToPatch(x_f);
         int patch_y = coordinateToPatch(y_f);

--- a/tt/src/main/java/com/oddlabs/tt/render/DefaultRenderer.java
+++ b/tt/src/main/java/com/oddlabs/tt/render/DefaultRenderer.java
@@ -237,6 +237,10 @@ public final class DefaultRenderer implements UIRenderer, AutoCloseable {
             GL11.glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_LINE);
         }
 
+        float seaLevel = aboveSea ? world.getHeightMap().getSeaLevelMeters() : -100.0f;
+        render_queues.getInstancedRenderer().setSeaLevel(seaLevel);
+        treeSpriteRenderer.setSeaLevel(seaLevel);
+
         // Sky & Landscape don't write to mask -> Disable Mask Buffer
         setDrawBuffers(false);
 

--- a/tt/src/main/java/com/oddlabs/tt/render/InstancedSpriteRenderer.java
+++ b/tt/src/main/java/com/oddlabs/tt/render/InstancedSpriteRenderer.java
@@ -35,12 +35,17 @@ public final class InstancedSpriteRenderer implements AutoCloseable {
     private final InstancedSpriteShader shader = new InstancedSpriteShader();
     private final Map<@NonNull BatchKey, @NonNull RenderBatch> batches = new HashMap<>();
     private final @NonNull Texture whiteTexture;
+    private float seaLevel = -100.0f;
 
     public InstancedSpriteRenderer() {
         GLImage whiteImage = new GLIntImage(1, 1, GL11.GL_RGBA);
         whiteImage.putPixel(0, 0, Color.WHITE_INT);
         whiteTexture = new Texture(new GLImage[]{whiteImage}, GL11.GL_RGBA8, GL11.GL_NEAREST, GL11.GL_NEAREST,
                 GL12.GL_CLAMP_TO_EDGE, GL12.GL_CLAMP_TO_EDGE);
+    }
+
+    public void setSeaLevel(float seaLevel) {
+        this.seaLevel = seaLevel;
     }
 
     public void add(@NonNull SpriteList spriteList, int spriteIndex, int animation, float animTicks, int texIndex,
@@ -62,6 +67,7 @@ public final class InstancedSpriteRenderer implements AutoCloseable {
         try (var _ = shader.use()) {
             // Set TBO texture unit
             shader.setUniform(InstancedSpriteShader.Uniforms.VERT_BUFFER, 5);
+            shader.setUniform(InstancedSpriteShader.Uniforms.SEA_LEVEL, seaLevel);
 
             RenderState state = new RenderState();
             for (RenderBatch batch : batches.values()) {

--- a/tt/src/main/java/com/oddlabs/tt/render/LandscapeRenderer.java
+++ b/tt/src/main/java/com/oddlabs/tt/render/LandscapeRenderer.java
@@ -225,7 +225,7 @@ public final class LandscapeRenderer implements SceneRenderer, Animated {
         public void visitLeaf(@NonNull LandscapeLeaf leaf) {
             if (visible_override || RenderTools.inFrustum(leaf,
                     camera.getFrustum()) != RenderTools.FrustumIntersection.ALL_OUTSIDE) {
-                if (!aboveSea || !heightMap.isBelowSeaLevel(leaf.getPatchX(), leaf.getPatchY())) {
+                if (!aboveSea || heightMap.isAboveSeaLevel(leaf.getPatchX(), leaf.getPatchY())) {
                     result.add(leaf);
                 }
             }

--- a/tt/src/main/java/com/oddlabs/tt/render/shader/InstancedSpriteShader.java
+++ b/tt/src/main/java/com/oddlabs/tt/render/shader/InstancedSpriteShader.java
@@ -20,6 +20,7 @@ public final class InstancedSpriteShader extends ShaderProgram implements FogSha
         String DESATURATE = "u_desaturate";
         String ALPHA_TEST_VALUE = "u_alphaTestValue";
         String CLASSIC_LIGHTING = "u_classicLighting";
+        String SEA_LEVEL = "u_seaLevel";
     }
 
     public interface Attributes {
@@ -65,6 +66,7 @@ public final class InstancedSpriteShader extends ShaderProgram implements FogSha
                 out vec3 v_viewPosition;
                 out vec3 v_viewNormal;
                 out vec3 v_lightIntensity;
+                out float v_worldZ;
 
                 void main() {
                     // Fetch vertex data for both frames
@@ -89,6 +91,7 @@ public final class InstancedSpriteShader extends ShaderProgram implements FogSha
                     vec4 viewPosition = u_viewMatrix * worldPosition;
                     gl_Position = u_projectionMatrix * viewPosition;
 
+                    v_worldZ = worldPosition.z;
                     v_texCoord0 = in_TexCoord;
                     v_color = in_InstanceColor;
                     v_decalColor = in_InstanceDecalColor;
@@ -121,6 +124,7 @@ public final class InstancedSpriteShader extends ShaderProgram implements FogSha
             uniform bool u_classicLighting;
             uniform float u_desaturate;
             uniform float u_alphaTestValue;
+            uniform float u_seaLevel;
 
             in vec2 v_texCoord0;
             in vec4 v_color;
@@ -129,11 +133,16 @@ public final class InstancedSpriteShader extends ShaderProgram implements FogSha
             in vec3 v_viewPosition;
             in vec3 v_viewNormal;
             in vec3 v_lightIntensity;
+            in float v_worldZ;
 
             layout(location = 0) out vec4 out_FragColor;
             layout(location = 1) out vec4 out_MaskColor;
 
             void main() {
+                if (v_worldZ < u_seaLevel) {
+                    discard;
+                }
+
                 vec4 base = texture(u_texture0, v_texCoord0);
                 out_MaskColor = vec4(0.0);
 

--- a/tt/src/main/java/com/oddlabs/tt/render/shader/WaterShader.java
+++ b/tt/src/main/java/com/oddlabs/tt/render/shader/WaterShader.java
@@ -198,7 +198,7 @@ public final class WaterShader extends ShaderProgram implements FogShader, LitSh
                 vec3 reflectionColor = u_fogColor.rgb;
                 vec2 reflectionOffset = vec2(0.0, 0.0);
                 if (u_enableDetail) {
-                    reflectionOffset = texture(u_texture1, v_texCoord0 * 2.0 + 0.01 * vec2(sin(u_globalTime * 4.0), cos(u_globalTime * 0.23))).xy * 0.1;
+                    reflectionOffset = texture(u_texture1, v_texCoord0 * 2.0 + 0.01 * vec2(sin(u_globalTime * 4.0), cos(u_globalTime * 0.23))).xy * 0.01;
                 }
                 if (u_hasReflection && v_reflectionClipPos.w > 0.0) {
                     vec2 reflUV = v_reflectionClipPos.xy / v_reflectionClipPos.w * 0.5 + 0.5;


### PR DESCRIPTION
Fixing weird water reflections

It had 2 reasons:

1. There was too much UV distortion. So in order to make the water look uneven and a bit random, we added a pattern of error that distorts the water. But it was too distorted that the reflection looks squished. Lower it to 10% of what it was helped making it look better.

2. Some 3D models go under the water level. For example, the boat oars and falling trees still had a bit of them under water. When rendering the above-water part, these under water parts should have been cut off since there's no way they would be seen in the reflection since they're literally under the water. The sprite shader had to do that cut-off at water level.
