### PR TITLE
One more weird reflection

### DIFF
--- a/tt/src/main/java/com/oddlabs/tt/render/LandscapeRenderer.java
+++ b/tt/src/main/java/com/oddlabs/tt/render/LandscapeRenderer.java
@@ -45,6 +45,7 @@ public final class LandscapeRenderer implements SceneRenderer, Animated {
     private final Vector4f lightDir = new Vector4f();
     private FloatVBO instanceVBO;
     private FloatBuffer instanceBuffer;
+    private boolean aboveSea = false;
 
     public @NonNull LandscapeShader getShader() {
         return shader;
@@ -80,6 +81,7 @@ public final class LandscapeRenderer implements SceneRenderer, Animated {
 
     public void prepareAll(@NonNull CameraState camera, boolean visible_override, boolean aboveSea) {
         render_list.clear();
+        this.aboveSea = aboveSea;
         doPrepareAll(camera, visible_override, aboveSea, render_list);
     }
 
@@ -99,6 +101,8 @@ public final class LandscapeRenderer implements SceneRenderer, Animated {
             // Set VTF Uniforms
             shader.setUniform(LandscapeShader.Uniforms.WORLD_SIZE, (float) world.getHeightMap().getMetersPerWorld());
             shader.setUniform(LandscapeShader.Uniforms.DETAIL_SCALE, Globals.LANDSCAPE_DETAIL_REPEAT_RATE);
+            float seaLevel = aboveSea ? world.getHeightMap().getSeaLevelMeters() : -100.0f;
+            shader.setUniform(LandscapeShader.Uniforms.SEA_LEVEL, seaLevel);
 
             context.setTexture(0, diffuseMap);
             shader.setUniform(LandscapeShader.Uniforms.DIFFUSE_MAP, 0);

--- a/tt/src/main/java/com/oddlabs/tt/render/shader/LandscapeShader.java
+++ b/tt/src/main/java/com/oddlabs/tt/render/shader/LandscapeShader.java
@@ -11,6 +11,7 @@ public final class LandscapeShader extends ShaderProgram implements FogShader, L
         String DETAIL_MAP = "u_DetailMap";
         String WORLD_SIZE = "u_WorldSize";
         String DETAIL_SCALE = "u_DetailScale";
+        String SEA_LEVEL = "u_SeaLevel";
         String LIGHT_DIRECTION = LitShader.Uniforms.LIGHT_DIR;
         String GLOBAL_AMBIENT = LitShader.Uniforms.GLOBAL_AMBIENT;
     }
@@ -35,6 +36,7 @@ public final class LandscapeShader extends ShaderProgram implements FogShader, L
             out float v_fogDist;
             out vec3 v_viewPosition;
             out vec3 v_viewNormal;
+            out float v_worldZ;
 
             void main() {
                 vec2 worldPos = in_InstancePatchOffset + in_Position;
@@ -55,6 +57,7 @@ public final class LandscapeShader extends ShaderProgram implements FogShader, L
                 vec4 viewPosition = u_viewMatrix * worldPosition4;
                 gl_Position = u_projectionMatrix * viewPosition;
 
+                v_worldZ = worldPosition4.z;
                 v_texCoord0 = uv;
                 v_texCoord1 = worldPos * u_DetailScale;
                 v_fogDist = length(viewPosition.xyz);
@@ -69,16 +72,22 @@ public final class LandscapeShader extends ShaderProgram implements FogShader, L
             uniform sampler2D u_DiffuseMap;
             uniform sampler2D u_NormalMap;
             uniform sampler2D u_DetailMap;
+            uniform float u_SeaLevel;
 
             in vec2 v_texCoord0;
             in vec2 v_texCoord1;
             in float v_fogDist;
             in vec3 v_viewPosition;
             in vec3 v_viewNormal;
+            in float v_worldZ;
 
             layout(location = 0) out vec4 out_FragColor;
 
             void main() {
+                if (v_worldZ < u_SeaLevel) {
+                    discard;
+                }
+
                 vec4 diffuseColor = texture(u_DiffuseMap, v_texCoord0);
                 vec4 detailColor = texture(u_DetailMap, v_texCoord1);
 


### PR DESCRIPTION
Let's recap, water reflections are rendered this way:

1- Take a picture of everything above the water.
2. Render the landscape
3. Render the water and use the picture taken at step 1 for reflections.

Why were there weird reflections?

Because step 1 wasn't exactly rendering everything above the water. Some parts were under the water too. For example, the submerged part of the ship, the oars, and falling trees. That created a distorted reflection.

The previous PR fixed the 3D models part where it clipped the model and only rendered the parts above the sea.

This PR does the same but for the landscape. Some parts of the landscape were underwater and yet they were rendered into the reflection texture. Creating reflections with patches like this:

<img width="1920" height="1080" alt="Screenshot_20260912_120304" src="https://github.com/user-attachments/assets/20f0ccbb-dfd3-4924-bd79-2e0e04fa64f2" />
