### PR TITLE
Fixing some crashes after the latest changes

### DIFF
--- a/tt/src/main/java/com/oddlabs/tt/model/LandBuilding.java
+++ b/tt/src/main/java/com/oddlabs/tt/model/LandBuilding.java
@@ -513,8 +513,14 @@ public final class LandBuilding extends Building {
                     return false;
                 }
                 var occ = unit_grid.getOccupant(cx, cy);
-                if (occ != null && !(occ instanceof Unit)) {
-                    return false;
+                if (occ != null) {
+                    if (occ instanceof Unit unit) {
+                        if (unit.isMoving()) {
+                            return false;
+                        }
+                    } else {
+                        return false;
+                    }
                 }
             }
         }

--- a/tt/src/main/java/com/oddlabs/tt/model/Unit.java
+++ b/tt/src/main/java/com/oddlabs/tt/model/Unit.java
@@ -254,6 +254,9 @@ public class Unit extends Selectable<UnitTemplate> implements Occupant, Movable 
     }
 
     public final void drown() {
+        if (isDead()) {
+            return;
+        }
         clearControllerStack();
         setReference(null);
         mounted = false;


### PR DESCRIPTION
There was a corner case after the previous changes with unit displacement when placing a building.

So if the unit was already moving, the path tracker gets confused because it already has planned a path for it. So if the unit is suddenly not where it's expected to be, an assert will fail.

To fix that, we have to check if the units are moving first. If there are moving units, the build site is not offered.